### PR TITLE
manually add unregistered DPP package

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,6 +43,7 @@ jobs:
             Pkg.Registry.add("General")
             Pkg.Registry.add(RegistrySpec(url = "https://github.com/cesmix-mit/CESMIX.git"))
             Pkg.Registry.add(RegistrySpec(url = "https://github.com/JuliaMolSim/MolSim.git"))
+            Pkg.add(url="https://github.com/dahtah/DPP.jl.git")
           '
         shell: bash
       - uses: julia-actions/julia-buildpkg@v1


### PR DESCRIPTION
Manually adds the DPP package during the registry step of the CI tests. 
I think this puts it in the global environment, rather than the test environment, which may not be the best...