### PR TITLE
Working tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.7"
+          - "1.8.5"
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"
-DPP = "2673d5e8-682c-11e9-2dfd-471b09c6c819"
+Determinantal = "2673d5e8-682c-11e9-2dfd-471b09c6c819"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 InteratomicPotentials = "a9efe35a-c65d-452d-b8a8-82646cd5cb04"

--- a/examples/LJ/lj.jl
+++ b/examples/LJ/lj.jl
@@ -3,7 +3,7 @@ using AtomsBase, Unitful, UnitfulAtomic, StaticArrays
 using InteratomicPotentials, InteratomicBasisPotentials
 using CairoMakie
 using JLD
-using DPP
+using Determinantal
 push!(Base.LOAD_PATH, dirname(@__DIR__))
 using PotentialLearning
 

--- a/examples/Sodium/fit_sodium_dft.jl
+++ b/examples/Sodium/fit_sodium_dft.jl
@@ -3,7 +3,7 @@ using AtomsBase, Unitful, UnitfulAtomic, StaticArrays
 using InteratomicPotentials, InteratomicBasisPotentials
 using CairoMakie
 using JLD
-using DPP
+using Determinantal
 push!(Base.LOAD_PATH, dirname(@__DIR__))
 using PotentialLearning
 

--- a/src/DimensionReduction/pca.jl
+++ b/src/DimensionReduction/pca.jl
@@ -25,5 +25,6 @@ function fit(ds::DataSet, pca::PCA)
     catch
         error("No local descriptors found in DataSet")
     end
-    λ, W = select_eigendirections(d .- mean.(d), pca.tol)
+    # dc = [di - mean(d) for di in d]
+    λ, W = select_eigendirections(d, pca.tol)
 end

--- a/src/SubsetSelection/dpp.jl
+++ b/src/SubsetSelection/dpp.jl
@@ -1,10 +1,10 @@
-using DPP
+using Determinantal
 """
     struct kDPP
         K :: EllEnsemble
     end
 
-A convenience function that allows the user access to a k-Determinantal Point Process through DPP.jl. All that is required to construct a kDPP is a similarity kernel, for which the user must provide a LinearProblem and two functions to compute descriptor (1) diversity and (2) quality. 
+A convenience function that allows the user access to a k-Determinantal Point Process through Determinantal.jl. All that is required to construct a kDPP is a similarity kernel, for which the user must provide a LinearProblem and two functions to compute descriptor (1) diversity and (2) quality. 
 """
 struct kDPP <: SubsetSelector
     K::EllEnsemble
@@ -13,7 +13,7 @@ end
 """
     kDPP(ds::Dataset, f::Feature, k::Kernel) 
 
-A convenience function that allows the user access to a k-Determinantal Point Process through DPP.jl. All that is required to construct a kDPP is a dataset, a method to compute features, and a kernel. Optional arguments include batch size and type of descriptor (default LocalDescriptors).
+A convenience function that allows the user access to a k-Determinantal Point Process through Determinantal.jl. All that is required to construct a kDPP is a dataset, a method to compute features, and a kernel. Optional arguments include batch size and type of descriptor (default LocalDescriptors).
 """
 function kDPP(
     ds::DataSet,
@@ -30,7 +30,7 @@ end
 """
     kDPP(features::Union{Vector{Vector{T}}, Vector{Symmetric{T, Matrix{T}}}}, k::Kernel) 
 
-A convenience function that allows the user access to a k-Determinantal Point Process through DPP.jl. All that is required to construct a kDPP are features (either a vector of vector features or a vector of symmetric matrix features) and a kernel. Optional argument is batch_size (default length(features)).
+A convenience function that allows the user access to a k-Determinantal Point Process through Determinantaljl. All that is required to construct a kDPP are features (either a vector of vector features or a vector of symmetric matrix features) and a kernel. Optional argument is batch_size (default length(features)).
 """
 function kDPP(
     features::Union{Vector{Vector{T}},Vector{Symmetric{T,Matrix{T}}}},
@@ -48,13 +48,13 @@ end
 Access a random subset of the data as sampled from the provided k-DPP. Returns the indices of the random subset and the subset itself.
 """
 function get_random_subset(dpp::kDPP; batch_size::Int = dpp.batch_size)
-    indices = DPP.sample(dpp.K, batch_size)
+    indices = Determinantal.sample(dpp.K, batch_size)
     return indices
 end
 """
     get_dpp_mode(dpp::kDPP, batch_size::Int) <: Vector{Int64}
 
-Access an approximate mode of the k-DPP as calculated by a greedy subset algorithm. See DPP.jl for details.
+Access an approximate mode of the k-DPP as calculated by a greedy subset algorithm. See Determinantal.jl for details.
 """
 function get_dpp_mode(dpp::kDPP; batch_size::Int = dpp.batch_size)
     indices = greedy_subset(dpp.K, batch_size)
@@ -63,8 +63,8 @@ end
 """
     get_inclusion_prob(dpp::kDPP) <: Vector{Float64}
 
-Access an approximation to the inclusion probabilities as calculated by DPP.jl (see package for details).
+Access an approximation to the inclusion probabilities as calculated by Determinantal.jl (see package for details).
 """
 function get_inclusion_prob(dpp::kDPP)
-    vec(DPP.inclusion_prob(dpp.K))
+    vec(Determinantal.inclusion_prob(dpp.K))
 end

--- a/test/dimension_reduction/dimension_reduction.jl
+++ b/test/dimension_reduction/dimension_reduction.jl
@@ -29,17 +29,13 @@ pca = PCA(num_dim)
 λ_as, W_as = fit(ds, as)
 @test typeof(λ_as) <: Vector{Float64}
 @test typeof(W_as) <: Matrix{Float64}
+@test size(W_as, 1) == d 
+@test size(W_as, 2) == num_dim
 
-# These fail because W_as has rows/columns flipped
-#@test size(W_as, 1) == num_dim
-#@test size(W_as, 2) == d
-#@test typeof(W_as * ds) <: DataSet
+λ_pca, W_pca = fit(ds, pca)
+@test typeof(λ_pca) <: Vector{Float64}
+@test typeof(W_pca) <: Matrix{Float64}
+@test size(W_pca, 1) == d
+@test size(W_pca, 2) == num_dim
 
-# PCA is also broken
-#λ_pca, W_pca = fit(ds, pca)
-#@test typeof(λ_pca) <: Vector{Float64}
-#@test typeof(W_pca) <: Matrix{Float64}
-#@test size(W_pca, 1) == num_dim
-#@test size(W_pca, 2) == d
-#
-#@test all(λ_as .≈ λ_pca)
+@test all(λ_as .≈ λ_pca)

--- a/test/dimension_reduction/dimension_reduction.jl
+++ b/test/dimension_reduction/dimension_reduction.jl
@@ -29,15 +29,17 @@ pca = PCA(num_dim)
 λ_as, W_as = fit(ds, as)
 @test typeof(λ_as) <: Vector{Float64}
 @test typeof(W_as) <: Matrix{Float64}
-@test size(W_as, 1) == num_dim
-@test size(W_as, 2) == d
 
-λ_pca, W_pca = fit(ds, pca)
-@test typeof(λ_pca) <: Vector{Float64}
-@test typeof(W_pca) <: Matrix{Float64}
-@test size(W_pca, 1) == num_dim
-@test size(W_pca, 2) == d
+# These fail because W_as has rows/columns flipped
+#@test size(W_as, 1) == num_dim
+#@test size(W_as, 2) == d
+#@test typeof(W_as * ds) <: DataSet
 
-@test all(λ_as .≈ λ_pca)
-
-@test typeof(W_as * ds) <: DataSet
+# PCA is also broken
+#λ_pca, W_pca = fit(ds, pca)
+#@test typeof(λ_pca) <: Vector{Float64}
+#@test typeof(W_pca) <: Matrix{Float64}
+#@test size(W_pca, 1) == num_dim
+#@test size(W_pca, 2) == d
+#
+#@test all(λ_as .≈ λ_pca)


### PR DESCRIPTION
Primarily fixes the DPP issue by updating the dependency to Determinantal. 

However, the dimension reduction tests currently fail in a number of spots. I have temporarily commented these out just to see if the CI passes. These issues need to be resolved:

- [x] Row/Column switch from b7a7776 caused a few tests to fail
Specifically [these 3 tests](https://github.com/cesmix-mit/PotentialLearning.jl/blob/f299f4f389d5d5e2c6eadcf613c72ae65ace58e5/test/dimension_reduction/dimension_reduction.jl#L33) fail. 
Presumably the first two can be resolved by just switching num_dim/d, while the last can be fixed with a transpose on W_as. However, I was a bit unsure if we were violating some other assumptions in the code with this row/col switch, so I'm waiting to make those changes. 

- [x] PCA is currently broken as well. 
This actually errors out prior to any of the tests, on the fit line. 
The issue is [this line](https://github.com/cesmix-mit/PotentialLearning.jl/blob/f299f4f389d5d5e2c6eadcf613c72ae65ace58e5/src/DimensionReduction/pca.jl#LL28C1-L28C1). 
In the test, there are 10 configurations and 8 descriptors. However, calling mean with the broadcast dot `mean.(d)` returns an array of length 10, i.e. for each configuration averaging the descriptors. Instead, I think we want just `mean(d)` which returns an array 8, i.e. for each descriptor, averaging over configurations. 
Secondly, I think we need something like 
```julia
mean_d = mean(d)
λ, W = select_eigendirections([dc - mean_d for dc in test_d], pca.tol)
```
However, I was a bit unsure what the `select_eigendirections` function expects, so again I wanted to wait before making those changes