### PR TITLE
Improve efficiency of kernel calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ docs/src/generated/
 
 # data too large for github
 examples/aHfO2/
+*.xyz
+*.csv

--- a/src/Kernels/kernels.jl
+++ b/src/Kernels/kernels.jl
@@ -90,9 +90,7 @@ function KernelMatrix(
     K = zeros(n, n)
     for i = 1:n
         for j = i:n
-            Kij = compute_kernel(F[i], F[j], k)
-            K[i, j] = Kij
-            K[j, i] = Kij
+            K[i, j] = compute_kernel(F[i], F[j], k)
         end
     end
     Symmetric(K)

--- a/src/Kernels/kernels.jl
+++ b/src/Kernels/kernels.jl
@@ -89,8 +89,10 @@ function KernelMatrix(
     n = length(F)
     K = zeros(n, n)
     for i = 1:n
-        for j = 1:n
-            K[i, j] = compute_kernel(F[i], F[j], k)
+        for j = i:n
+            Kij = compute_kernel(F[i], F[j], k)
+            K[i, j] = Kij
+            K[j, i] = Kij
         end
     end
     Symmetric(K)


### PR DESCRIPTION
Small change to reduce the cost of computing symmetric kernel matrices. Only one half of the matrix terms [Kij] are computed, then copied over to [Kji]. 

The code is verified to return the same matrix as the original code. 