### PR TITLE
Quick fix to use pinv only when necessary for WLS

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PotentialLearning"
 uuid = "82b0a93c-c2e3-44bc-a418-f0f89b0ae5c2"
 authors = ["CESMIX Team"]
-version = "0.2.5"
+version = "0.2.6"
 
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"

--- a/src/Learning/linear-learn.jl
+++ b/src/Learning/linear-learn.jl
@@ -194,7 +194,15 @@ function learn!(
 
     # Calculate coefficients β.
     Q = Diagonal(ws[1] * ones(length(e_train)))
-    βs = pinv(A'*Q*A)*(A'*Q*b)
+
+    βs = Vector{Float64}() 
+    try
+        βs = (A'*Q*A) \ (A'*Q*b)
+    catch e
+        println(e)
+        println("Linear system will be solved using pinv.") 
+        βs = pinv(A'*Q*A)*(A'*Q*b)
+    end
     
     # Update lp.
     if int
@@ -238,7 +246,15 @@ function learn!(
     # Calculate coefficients βs.
     Q = Diagonal([ws[1] * ones(length(e_train));
                   ws[2] * ones(length(f_train))])
-    βs = pinv(A'*Q*A)*(A'*Q*b)
+    
+    βs = Vector{Float64}() 
+    try
+        βs = (A'*Q*A) \ (A'*Q*b)
+    catch e
+        println(e)
+        println("Linear system will be solved using pinv.") 
+        βs = pinv(A'*Q*A)*(A'*Q*b)
+    end
 
     # Update lp.
     if int


### PR DESCRIPTION
This is just a quick fix to get better fitting errors when pinv is not needed.  We will need a robust approach to fitting these problems in the future though. 